### PR TITLE
feat: implement add account form with account type selection

### DIFF
--- a/backend/app/api/v1/account_types.py
+++ b/backend/app/api/v1/account_types.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.database import get_db
+from app.models import AccountType as AccountTypeModel
+from app.schemas import AccountType
+
+router = APIRouter()
+
+@router.get("/", response_model=List[AccountType])
+def get_account_types(db: Session = Depends(get_db)):
+    """Get all account types"""
+    return db.query(AccountTypeModel).all()

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,11 +1,13 @@
 from fastapi import APIRouter
 
 from .accounts import router as accounts_router
+from .account_types import router as account_types_router
 from .categories import router as categories_router
 from .transactions import router as transactions_router
 
 api_router = APIRouter()
 
 api_router.include_router(accounts_router, prefix="/accounts", tags=["accounts"])
+api_router.include_router(account_types_router, prefix="/account-types", tags=["account-types"])
 api_router.include_router(categories_router, prefix="/categories", tags=["categories"])
 api_router.include_router(transactions_router, prefix="/transactions", tags=["transactions"])

--- a/frontend/src/components/AddAccountForm.tsx
+++ b/frontend/src/components/AddAccountForm.tsx
@@ -1,0 +1,289 @@
+import { useState, useEffect } from 'react'
+import clsx from 'clsx'
+import type { AccountType, AccountCreate } from '../types/account'
+
+interface AddAccountFormProps {
+  onCancel: () => void
+  onSuccess: () => void
+}
+
+export default function AddAccountForm({ onCancel, onSuccess }: AddAccountFormProps) {
+  const [accountTypes, setAccountTypes] = useState<AccountType[]>([])
+  const [loading, setLoading] = useState(false)
+  const [loadingTypes, setLoadingTypes] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  
+  const [formData, setFormData] = useState<AccountCreate>({
+    name: '',
+    account_type_id: '',
+    balance: '0.00',
+    institution: '',
+    account_number: '',
+    currency: 'CAD',
+    is_active: true
+  })
+
+  useEffect(() => {
+    fetchAccountTypes()
+  }, [])
+
+  const fetchAccountTypes = async () => {
+    try {
+      setLoadingTypes(true)
+      const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+      const response = await fetch(`${apiBaseUrl}/api/v1/account-types/`)
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+      const data = await response.json()
+      setAccountTypes(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load account types')
+    } finally {
+      setLoadingTypes(false)
+    }
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value, type } = e.target
+    
+    setFormData(prev => ({
+      ...prev,
+      [name]: type === 'checkbox' ? (e.target as HTMLInputElement).checked : value
+    }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    
+    if (!formData.name.trim() || !formData.account_type_id) {
+      setError('Please fill in all required fields')
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+      const response = await fetch(`${apiBaseUrl}/api/v1/accounts/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          ...formData,
+          balance: parseFloat(formData.balance || '0').toString()
+        })
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.detail || `HTTP error! status: ${response.status}`)
+      }
+
+      onSuccess()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create account')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const getAccountTypeIcon = (category: string, subCategory: string) => {
+    if (category === 'ASSET') {
+      switch (subCategory) {
+        case 'cash': return '💰'
+        case 'investment': return '📈'
+        case 'real_estate': return '🏠'
+        default: return '🏦'
+      }
+    } else { // LIABILITY
+      switch (subCategory) {
+        case 'debt': return '💳'
+        default: return '📋'
+      }
+    }
+  }
+
+  if (loadingTypes) {
+    return (
+      <div className="animate-pulse">
+        <div className="space-y-4">
+          <div className="bg-gray-200 h-4 w-1/4 rounded"></div>
+          <div className="bg-gray-200 h-12 rounded-lg"></div>
+          <div className="bg-gray-200 h-4 w-1/4 rounded"></div>
+          <div className="bg-gray-200 h-12 rounded-lg"></div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex items-center gap-2 text-red-800">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span className="font-medium">Error</span>
+          </div>
+          <p className="text-red-700 mt-2">{error}</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="md:col-span-2">
+          <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
+            Account Name *
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            value={formData.name}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="e.g., My Primary Checking"
+            required
+          />
+        </div>
+
+        <div className="md:col-span-2">
+          <label htmlFor="account_type_id" className="block text-sm font-medium text-gray-700 mb-2">
+            Account Type *
+          </label>
+          <select
+            id="account_type_id"
+            name="account_type_id"
+            value={formData.account_type_id}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            required
+          >
+            <option value="">Select an account type...</option>
+            {accountTypes.map((type) => (
+              <option key={type.id} value={type.id}>
+                {getAccountTypeIcon(type.category, type.sub_category)} {type.name} ({type.category})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="balance" className="block text-sm font-medium text-gray-700 mb-2">
+            Initial Balance
+          </label>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+            <input
+              type="number"
+              id="balance"
+              name="balance"
+              value={formData.balance}
+              onChange={handleInputChange}
+              step="0.01"
+              min="0"
+              className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="0.00"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="currency" className="block text-sm font-medium text-gray-700 mb-2">
+            Currency
+          </label>
+          <select
+            id="currency"
+            name="currency"
+            value={formData.currency}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          >
+            <option value="CAD">🇨🇦 CAD</option>
+            <option value="USD">🇺🇸 USD</option>
+            <option value="EUR">🇪🇺 EUR</option>
+            <option value="GBP">🇬🇧 GBP</option>
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="institution" className="block text-sm font-medium text-gray-700 mb-2">
+            Institution
+          </label>
+          <input
+            type="text"
+            id="institution"
+            name="institution"
+            value={formData.institution}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="e.g., TD Bank, RBC"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="account_number" className="block text-sm font-medium text-gray-700 mb-2">
+            Account Number (Last 4 digits)
+          </label>
+          <input
+            type="text"
+            id="account_number"
+            name="account_number"
+            value={formData.account_number}
+            onChange={handleInputChange}
+            maxLength={4}
+            pattern="[0-9]*"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="1234"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center">
+        <input
+          type="checkbox"
+          id="is_active"
+          name="is_active"
+          checked={formData.is_active}
+          onChange={handleInputChange}
+          className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+        />
+        <label htmlFor="is_active" className="ml-2 text-sm text-gray-700">
+          Account is active
+        </label>
+      </div>
+
+      <div className="flex justify-end gap-3 pt-4 border-t">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className={clsx(
+            'px-4 py-2 text-white bg-blue-600 rounded-lg font-medium transition-colors',
+            loading 
+              ? 'opacity-50 cursor-not-allowed' 
+              : 'hover:bg-blue-700'
+          )}
+        >
+          {loading ? (
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
+              Creating...
+            </div>
+          ) : (
+            'Create Account'
+          )}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import AddAccountForm from '../components/AddAccountForm'
 
 type AccountView = 'list' | 'add' | 'edit'
 
@@ -11,6 +12,10 @@ export default function Accounts() {
     setSelectedAccountId(null)
   }
 
+  const handleAddAccountSuccess = () => {
+    setCurrentView('list')
+    // In a real app, you might want to refresh the account list here
+  }
 
   const handleBackToList = () => {
     setCurrentView('list')
@@ -64,10 +69,10 @@ export default function Accounts() {
 
         {currentView === 'add' && (
           <div className="p-6">
-            <p className="text-gray-600 mb-4">Add a new financial account.</p>
-            <div className="text-sm text-gray-500">
-              Add account form will be implemented next.
-            </div>
+            <AddAccountForm 
+              onCancel={handleBackToList}
+              onSuccess={handleAddAccountSuccess}
+            />
           </div>
         )}
 

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -1,0 +1,42 @@
+export interface AccountType {
+  id: string
+  name: string
+  category: 'ASSET' | 'LIABILITY'
+  sub_category: 'cash' | 'investment' | 'debt' | 'real_estate'
+  created_at: string
+  updated_at: string
+}
+
+export interface Account {
+  id: string
+  name: string
+  account_type_id: string
+  balance: string
+  institution?: string
+  account_number?: string
+  currency: string
+  is_active: boolean
+  created_at: string
+  updated_at: string
+  account_type?: AccountType
+}
+
+export interface AccountCreate {
+  name: string
+  account_type_id: string
+  balance?: string
+  institution?: string
+  account_number?: string
+  currency?: string
+  is_active?: boolean
+}
+
+export interface AccountUpdate {
+  name?: string
+  account_type_id?: string
+  balance?: string
+  institution?: string
+  account_number?: string
+  currency?: string
+  is_active?: boolean
+}


### PR DESCRIPTION
## Summary
- Add comprehensive AddAccountForm component with dynamic account type selection
- Create /api/v1/account-types/ backend endpoint for fetching available account types
- Implement full-featured form with validation, loading states, and error handling
- Support for all account fields including balance, institution, currency, and account number

## Changes Made

### Frontend
- **AddAccountForm component**: Complete form with TypeScript types and validation
- **Account type selection**: Dynamic dropdown populated from backend API
- **Form validation**: Required field validation with error messages
- **Loading states**: Skeleton loading for account types, spinner for form submission
- **Currency support**: Multi-currency selection with flag emojis
- **Responsive design**: Mobile-friendly layout with proper accessibility

### Backend  
- **New API endpoint**: `/api/v1/account-types/` for fetching account types
- **API router integration**: Added account types endpoint to main router
- **Consistent with existing patterns**: Follows same structure as other API endpoints

## Test Plan
- [x] Frontend builds without TypeScript errors
- [x] Backend API endpoint returns account types correctly
- [x] Form validation works for required fields
- [x] Loading states display properly
- [ ] Test form submission with valid data
- [ ] Verify account creation in database
- [ ] Test error handling for API failures
- [ ] Verify navigation flow (cancel/success)

## API Integration
- Uses environment variable `VITE_API_BASE_URL` for API base URL
- Handles API errors gracefully with user-friendly messages
- Maintains consistent error handling patterns with existing code

🤖 Generated with [Claude Code](https://claude.ai/code)